### PR TITLE
Only use Robots' delay if it is shorter than Options' delay

### DIFF
--- a/ext.go
+++ b/ext.go
@@ -96,9 +96,9 @@ func (this *DefaultExtender) Log(logFlags LogFlags, msgLevel LogFlags, msg strin
 }
 
 // ComputeDelay returns the delay specified in the Crawler's Options, unless a
-// shorter crawl-delay is specified in the robots.txt file, which has precedence.
+// longer crawl-delay is specified in the robots.txt file, which has precedence.
 func (this *DefaultExtender) ComputeDelay(host string, di *DelayInfo, lastFetch *FetchInfo) time.Duration {
-	if di.RobotsDelay > 0 && di.RobotsDelay < di.OptsDelay {
+	if di.RobotsDelay > 0 && di.RobotsDelay > di.OptsDelay {
 		return di.RobotsDelay
 	}
 	return di.OptsDelay


### PR DESCRIPTION
If the robots.txt delay is shorter than the delay specified by the user, we use the robots.txt delay. However, if we request a delay which is longer than that in robots.txt, we will continue to use our longer delay.
