### PR TITLE
fixed 'receive url(s) to enqueue'

### DIFF
--- a/crawler.go
+++ b/crawler.go
@@ -320,7 +320,7 @@ func (c *Crawler) collectUrls() error {
 		case enq := <-c.enqueue:
 			// Received a command to enqueue a URL, proceed
 			ctxs := c.toURLContexts(enq, nil)
-			c.logFunc(LogTrace, "receive url(s) to enqueue %v", ctxs)
+			c.logFunc(LogTrace, "receive url(s) to enqueue %v", toStringArrayContextURL(ctxs))
 			c.enqueueUrls(ctxs)
 		case <-c.stop:
 			return ErrInterrupted

--- a/urlcontext.go
+++ b/urlcontext.go
@@ -108,6 +108,9 @@ func isRobotsURL(u *url.URL) bool {
 	func toStringArrayContextURL(list []*URLContext) string {
 	var str string
 	for _, item := range list {
+		if len(str) != 0 {
+			str += ", "
+		}
 		str += item.NormalizedURL().String()
 	}
 	return str

--- a/urlcontext.go
+++ b/urlcontext.go
@@ -105,6 +105,14 @@ func isRobotsURL(u *url.URL) bool {
 	return strings.ToLower(u.Path) == robotsTxtPath
 }
 
+	func toStringArrayContextURL(list []*URLContext) string {
+	var str string
+	for _, item := range list {
+		str += item.NormalizedURL().String()
+	}
+	return str
+}
+
 func (uc *URLContext) getRobotsURLCtx() (*URLContext, error) {
 	robURL, err := uc.normalizedURL.Parse(robotsTxtPath)
 	if err != nil {


### PR DESCRIPTION
I found issue in log report. 

Before:
`2016/11/20 17:28:39 receive url(s) to enqueue [0xc8203403c0]`

After:
`2016/11/20 17:38:07 receive url(s) to enqueue http://*****/Seller/Jewelry-Gemstones`

Tests:

> PASS
ok  	github.com/PuerkitoBio/gocrawl	23.900s